### PR TITLE
chore(ci): match Ember Data version in LTS tests

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,6 +6,16 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: volta-cli/action@v1
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+    - uses: actions/cache@v1
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
     - name: Install Dependencies
       run: yarn install
     - name: Run ESLint
@@ -19,6 +29,16 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: volta-cli/action@v1
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+    - uses: actions/cache@v1
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
     - name: Install Dependencies
       run: yarn install
     - name: Run Tests

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -64,9 +64,16 @@ jobs:
           ${{ runner.os }}-yarn-
     - name: Install Dependencies
       run: yarn install
-    - name: Run Tests
-      run: yarn ember try:one ${{ matrix.ember-try-scenario }} --skip-cleanup=true
+    - name: Build Scenario
+      run: yarn ember try:one ${{ matrix.ember-try-scenario }} --skip-cleanup=true --- ember build --environment=test
       env:
         CI: true
-
-
+    - name: Store Build Artifact for Debugging
+      uses: actions/upload-artifact@v1
+      with:
+        name: ${{ matrix.ember-try-scenario }}-dist
+        path: ./dist
+    - name: Run Tests
+      run: yarn ember test --path ./dist
+      env:
+        CI: true

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,39 +1,17 @@
 on: [push]
 
 jobs:
-  install:
+  lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: volta-cli/action@v1
-    - name: Cache Dependencies
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
     - name: Install Dependencies
       run: yarn install
-
-  lint:
-    needs: install
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: volta-cli/action@v1
-    - name: Cache Dependencies
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
     - name: Run ESLint
       run: yarn lint:js -f tap
 
   test:
-    needs: install
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -41,13 +19,8 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: volta-cli/action@v1
-    - name: Cache Dependencies
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
+    - name: Install Dependencies
+      run: yarn install
     - name: Run Tests
       run: yarn ember try:one ${{ matrix.ember-try-scenario }}
       env:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -23,9 +23,6 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ember-try-scenario: [ember-default, ember-lts-3.12, ember-lts-3.16, ember-release, ember-beta, ember-canary, ember-classic]
     steps:
     - uses: actions/checkout@v1
     - uses: volta-cli/action@v1
@@ -42,7 +39,33 @@ jobs:
     - name: Install Dependencies
       run: yarn install
     - name: Run Tests
-      run: yarn ember try:one ${{ matrix.ember-try-scenario }}
+      run: yarn test
+      env:
+        CI: true
+
+  ember-try:
+    needs: test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ember-try-scenario: [ember-lts-3.12, ember-lts-3.16, ember-release, ember-beta, ember-canary]
+    steps:
+    - uses: actions/checkout@v1
+    - uses: volta-cli/action@v1
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+    - uses: actions/cache@v1
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+    - name: Install Dependencies
+      run: yarn install
+    - name: Run Tests
+      run: yarn ember try:one ${{ matrix.ember-try-scenario }} --skip-cleanup=true
       env:
         CI: true
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -47,31 +47,6 @@ module.exports = async function() {
             'ember-source': await getChannelURL('canary')
           }
         }
-      },
-      // The default `.travis.yml` runs this scenario via `yarn test`,
-      // not via `ember try`. It's still included here so that running
-      // `ember try:each` manually or from a customized CI config will run it
-      // along with all the other scenarios.
-      {
-        name: 'ember-default',
-        npm: {
-          devDependencies: {}
-        }
-      },
-      {
-        name: 'ember-classic',
-        env: {
-          EMBER_OPTIONAL_FEATURES: JSON.stringify({
-            'application-template-wrapper': true,
-            'default-async-observers': false,
-            'template-only-glimmer-components': false
-          })
-        },
-        npm: {
-          ember: {
-            edition: 'classic'
-          }
-        }
       }
     ]
   };

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -10,6 +10,7 @@ module.exports = async function() {
         name: 'ember-lts-3.12',
         npm: {
           devDependencies: {
+            'ember-data': '~3.12.0',
             'ember-source': '~3.12.0'
           }
         }
@@ -18,6 +19,7 @@ module.exports = async function() {
         name: 'ember-lts-3.16',
         npm: {
           devDependencies: {
+            'ember-data': '~3.16.0',
             'ember-source': '~3.16.0'
           }
         }

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -1,14 +1,5 @@
 'use strict';
 
-const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
-
-const isCI = !!process.env.CI;
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
-  browsers
+  browsers: ['last 1 Chrome versions']
 };


### PR DESCRIPTION
The 3.12 tests failed in #4 so I want to land this as a separate PR to establish a baseline that the current work on `master` actually _does_ work in Ember 3.12.

It should, since the add-on seems to work in our own Ember app that uses Ember 3.12.